### PR TITLE
fix: decrease plugin priority

### DIFF
--- a/kong-plugin-api-response-merger-1.2.1-1.rockspec
+++ b/kong-plugin-api-response-merger-1.2.1-1.rockspec
@@ -1,5 +1,5 @@
 package= "kong-plugin-api-response-merger"
-version = "1.2.0-1"
+version = "1.2.1-1"
 description = {
   summary = "Kong plugin for merging responses from microservices",
   homepage = "http://github.com/inveox-lab-it/kong-plugin-api-response-merger",
@@ -7,7 +7,7 @@ description = {
 }
 source = {
   url = "git://github.com/inveox-lab-it/kong-plugin-api-response-merger",
-  tag = "1.2.0"
+  tag = "1.2.1"
 }
 dependencies = {}
 supported_platforms = {

--- a/kong/plugins/api-response-merger/handler.lua
+++ b/kong/plugins/api-response-merger/handler.lua
@@ -109,8 +109,8 @@ function APIResponseMergerHandler.init_worker()
   monitoring.init()
 end
 
-APIResponseMergerHandler.PRIORITY = 1000
-APIResponseMergerHandler.VERSION = '1.0.0'
+APIResponseMergerHandler.PRIORITY = -100
+APIResponseMergerHandler.VERSION = '1.2.1'
 
 return APIResponseMergerHandler
 


### PR DESCRIPTION
This will allows to run other plugins before api-repsone-merger (for
example correlation-id plugin)