### PR TITLE
fix(resource_id_optional): [LIT03-585] BE: unable to retrieve DLO with null relatedLabId via api-gw

### DIFF
--- a/kong/plugins/api-response-merger/body_transformer.lua
+++ b/kong/plugins/api-response-merger/body_transformer.lua
@@ -288,10 +288,8 @@ function _M.transform_json_body(keys_to_extend, upstream_body, http_config)
     -- multiple resources
 
     if resource_body == nil and config.resource_id_optional == true then
-      return true, upstream_body
-    end
-
-    if utils.is_array(upstream_body, 'fast') then
+      kong.log.warn('resource id is missing. skip processing for resource_key=', resource_key)
+    elseif utils.is_array(upstream_body, 'fast') then
       local ok, err = set_in_table_arr(resource_key, upstream_body, resource_body, config)
       if not ok then
         return false, create_error_response(err, config.api.url, 200, resource_body)
@@ -303,7 +301,7 @@ function _M.transform_json_body(keys_to_extend, upstream_body, http_config)
       end
       set_in_table(resource_key, upstream_body, resource_body, resource)
     end
-  end
+end
 
   return true, upstream_body
 end

--- a/spec/02_access_spec.lua
+++ b/spec/02_access_spec.lua
@@ -571,6 +571,38 @@ describe("Plugin: api-response-merger access", function()
     assert.same(expected, json)
   end)
 
+  it("should return data on resource id optional", function()
+    local array = {
+      d = {  id = 'cfg-id' },
+      foo = 'bar-sec'
+    }
+    upstream = http_server_with_body(upstream_port, cjson.encode(array))
+    service_c = http_server_with_body(service_c_port, '{ "org":{"name": "cfg-id"}, "something": "important"}')
+    helpers.wait_until(function()
+      return service_c:alive() and upstream:alive()
+    end, 1)
+
+    local res = proxy_client:get("/resource-id-optional", {
+      headers = {
+        host = "service.test",
+        ["Content-Type"] = "application/json",
+      },
+    })
+    local body = assert.res_status(200, res)
+    local json = cjson.decode(body)
+
+    local expected = {
+       d = {
+        org = {
+          name = 'cfg-id',
+        },
+        something = 'important'
+      },
+        foo = 'bar-sec',
+      }
+    assert.same(expected, json)
+  end)
+
   it("should allow resource id optional key if allowed by config", function()
     local array = {
       d = nil,


### PR DESCRIPTION
fix(resource_id_optional): [LIT03-585] BE: unable to retrieve DLO with null relatedLabId via api-gw